### PR TITLE
Add deploy job to continuous delivery workflow

### DIFF
--- a/.github/workflows/continuousdelivery.yml
+++ b/.github/workflows/continuousdelivery.yml
@@ -17,3 +17,12 @@ jobs:
           path: |
             '**.py'
             README.md
+  deploy:
+    runs-on: ubuntu-latest
+    needs: deliver
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: zipproject.zip
+      - name: Display structure of downloaded files
+        run: ls -R


### PR DESCRIPTION
# Summary
  - Add deploy job to continuous delivery workflow that downloads artifacts and displays file structure
  - Enhances the CD pipeline with a deployment step that depends on the deliver job

  ## Changes
  - Added `deploy` job to `.github/workflows/continuousdelivery.yml`
  - Job downloads the `zipproject.zip` artifact created by the deliver job
  - Displays structure of downloaded files using `ls -R`

  ## Test plan
  - [ ] Verify workflow runs successfully on push to main branch
  - [ ] Confirm artifact is properly downloaded in deploy job
  - [ ] Check that file structure is displayed correctly in workflow logs
