### PR TITLE
Fix Flask route handler type error in auth callback

### DIFF
--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -78,6 +78,10 @@ def callback():
 
             return jsonify(session["user_profile"])
 
+        else:
+            # Handle unsupported HTTP methods
+            return jsonify({"error": "Method not allowed"}), 405
+
     except Exception as e:
         if request.method == "POST":
             return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
Add missing return path for unsupported HTTP methods to prevent implicit None return that caused type incompatibility.